### PR TITLE
FEATURE: support of explicit conversions

### DIFF
--- a/src/main/java/parser/TreeMappings.kt
+++ b/src/main/java/parser/TreeMappings.kt
@@ -290,14 +290,23 @@ fun ExpressionContext.toArrayAccess(): ArrayAccess? {
     return null
 }
 
+fun ExpressionContext.toCastExpr(): Cast? {
+    val typeList = typeType()
+    val expr = expression(0)
+    if (LPAREN() != null && RPAREN() != null && typeList.isNotEmpty() && expr != null) {
+        return Cast(TypeList(typeList[0].toType()), expr.toExpression())
+    }
+    return null
+}
+
 fun ExpressionContext.toExpression(): Expression {
     val expr0 =
-        this.toArrayAccess() ?: this.toUnaryPrefixPostfix() ?: expression(0)?.toExpression()
+        this.toArrayAccess() ?: this.toUnaryPrefixPostfix() ?: this.toCastExpr() ?: expression(0)?.toExpression()
         ?: primary()?.toExpression() ?: identifier()?.toExpression() ?: creator()?.toExpression()
         ?: methodCall()?.toExpression(null) ?: SimpleReference(CompoundName("expression_placeholder")) /* FIXME */
     if (this.bop != null) {
         val expr1 =
-            this.toArrayAccess() ?: this.toUnaryPrefixPostfix() ?: expression(1)?.toExpression()
+            this.toArrayAccess() ?: this.toUnaryPrefixPostfix() ?: this.toCastExpr() ?: expression(1)?.toExpression()
             ?: primary()?.toExpression()
             ?: identifier()?.toExpression() ?: creator()?.toExpression() ?: methodCall()?.toExpression(expr0)
             ?: SimpleReference(CompoundName("expression_placeholder")) /* FIXME */

--- a/src/main/java/translator/Expressions.kt
+++ b/src/main/java/translator/Expressions.kt
@@ -4,12 +4,10 @@ import arrow.core.None
 import arrow.core.flatten
 import eotree.*
 import lexer.TokenCode
-import tree.Expression.Binary
-import tree.Expression.Expression
+import tree.Expression.*
 import tree.Expression.Primary.*
-import tree.Expression.SimpleReference
-import tree.Expression.UnaryPostfix
-import tree.Expression.UnaryPrefix
+import tree.Type.PrimitiveType
+import tree.Type.TypeName
 
 fun mapExpression(expr: Expression, name: String): List<EOBndExpr> =
     when (expr) {
@@ -37,6 +35,8 @@ fun mapExpression(expr: Expression, name: String): List<EOBndExpr> =
             mapArrayCreation(expr, name)
         is ArrayAccess ->
             mapArrayAccess(expr, name)
+        is Cast ->
+            mapCastExpr(expr, name)
         else ->
             throw IllegalArgumentException("Expression of type ${expr.javaClass.simpleName} is not supported")
     }
@@ -67,9 +67,39 @@ fun constructExprName(expr: Expression): String =
             "a_c${expr.hashCode()}"
         is ArrayAccess ->
             "a_a${expr.hashCode()}"
+        is Cast ->
+            "c${expr.hashCode()}"
         else ->
             throw IllegalArgumentException("Expression of type ${expr.javaClass.simpleName} is not supported")
     }
+
+fun mapCastExpr(cast: Cast, name: String): List<EOBndExpr> {
+    val castType = cast.types.types[0]
+    return listOf(
+        EOBndExpr(
+            EOObject(
+                listOf(),
+                None,
+                listOf(
+                    EOBndExpr(
+                        EOCopy(
+                            (when(castType) {
+                                    is PrimitiveType -> listOf(decodePrimitiveType(castType).value)
+                                    is TypeName -> castType.compoundName.names
+                                    else -> listOf("unknown_type_${castType.javaClass.simpleName}")
+                                } +
+                                listOf("from")
+                            ).eoDot(),
+                            constructExprName(cast.expression).eoDot()
+                        ),
+                        "@"
+                    )
+                )
+            ),
+            name
+        )
+    ) + mapExpression(cast.expression, constructExprName(cast.expression))
+}
 
 fun mapArrayAccess(access: ArrayAccess, name: String): List<EOBndExpr> {
     return listOf(

--- a/src/main/resources/stdlib/primitives/prim__int.eo
+++ b/src/main/resources/stdlib/primitives/prim__int.eo
@@ -102,18 +102,12 @@
 
   [right] > from
     seq > @
-      if.
-        or.
-          right.prim_name.eq "prim__float"
-          right.prim_name.eq "prim__double"
-        prim__int.constructor_2
-          prim__int.new
-          right.v.as-int.mod
-            max_int
-        prim__int.constructor_2
-          prim__int.new
-          right.v.mod
-            max_int
+      prim__int.constructor_2
+        prim__int.new
+        mod.
+          right.integer_part
+            right
+          max_int
 
   [this] > constructor_1
     seq > @

--- a/src/main/resources/stdlib/primitives/prim__num.eo
+++ b/src/main/resources/stdlib/primitives/prim__num.eo
@@ -12,6 +12,42 @@
         seq > @
           ^.v.as-string
 
+      [this] > integer_part
+        seq > @
+          if.
+            not.
+              this.prim_name.eq "prim__boolean"
+            if.
+              and.
+                not.
+                  this.prim_name.eq "prim__float"
+                not.
+                  this.prim_name.eq "prim__double"
+              this.v
+              this.v.as-int
+            if.
+              this.v
+              1
+              0
+
+      [this] > float_part
+        seq > @
+          if.
+            not.
+              this.prim_name.eq "prim__boolean"
+            if.
+              and.
+                not.
+                  this.prim_name.eq "prim__float"
+                not.
+                  this.prim_name.eq "prim__double"
+              this.v.as-float
+              this.v
+            if.
+              this.v
+              1.0
+              0.0
+
       [this value] > init
         seq > @
           this.v.write


### PR DESCRIPTION
## Support of explicit conversions
#### There is a runtime support only for explicit conversions to int:
```java
int a = (int) 1.0;// There is a runtime support
float a = (float) 1;// There is not a runtime support
```
## Example:
#### Input:
```
...
int a = (int) 1.0;
...
```
#### Result:
```
seq > @
  d1176735295
prim__int.constructor_1 > a
  prim__int.new
[] > d1176735295
  a.write > @
    i_s1169146729
[] > i_s1169146729
  c1095293768 > @
[] > c1095293768
  prim__int.from > @
    l673186785
[] > l673186785
  prim__float.constructor_2 > @
    prim__float.new
    1.0
```