### PR TITLE
Support of null added

### DIFF
--- a/src/main/java/translator/Literals.kt
+++ b/src/main/java/translator/Literals.kt
@@ -57,11 +57,17 @@ fun mapLiteral(literal: Literal, name: String, context: Context): EOBndExpr =
             name
         )
         TokenCode.Null -> {
-            logger.warn { "null value is not supported yet; falling back to 0" }
-            generateEOData( /* FIXME: use proper null */
-                listOf(TokenCodes.PRIM__INT.value, "constructor_2").eoDot(),
-                listOf(TokenCodes.PRIM__INT.value, "new").eoDot(),
-                EOIntData(0),
+            EOBndExpr(
+                EOObject(
+                    listOf(),
+                    None,
+                    listOf(
+                        EOBndExpr(
+                            "null".eoDot(),
+                            "@"
+                        )
+                    )
+                ),
                 name
             )
         }

--- a/src/main/java/util/NewGenerator.kt
+++ b/src/main/java/util/NewGenerator.kt
@@ -86,6 +86,10 @@ fun generateNewBody(clsDec: NormalClassDeclaration, context: Context): List<EOBn
             EOStringData(clsDec.name),
             "className"
         ),
+        EOBndExpr(
+            "1".eoDot(),
+            "address"
+        ),
         generateInit(clsDec, context)
     ) + (
         clsDec.body?.declarations

--- a/src/main/java/util/PrimitiveTypesFinder.kt
+++ b/src/main/java/util/PrimitiveTypesFinder.kt
@@ -38,6 +38,7 @@ private fun decodeLiteralCode(code: TokenCode): TokenCodes? {
         TokenCode.StringLiteral -> TokenCodes.CLASS__STRING
         TokenCode.False -> TokenCodes.PRIM__BOOLEAN
         TokenCode.True -> TokenCodes.PRIM__BOOLEAN
+        TokenCode.Null -> TokenCodes.NULL
         else -> null
     }
 }

--- a/src/main/java/util/TokenCodes.kt
+++ b/src/main/java/util/TokenCodes.kt
@@ -14,5 +14,5 @@ enum class TokenCodes(val value: String, val importPath: String) {
     CLASS__STRING("class__String", "stdlib.lang.class__String"),
     CLASS__OBJECT("class__Object", "stdlib.lang.class__Object"),
     CLASS__RANDOM("class__Random", "stdlib.util.class__Random"),
-    // EO_CAGE("gray.cage", "org.eolang.gray.cage")
+    NULL("null", "stdlib.primitives.null"),
 }

--- a/src/main/resources/stdlib/primitives/null.eo
+++ b/src/main/resources/stdlib/primitives/null.eo
@@ -1,0 +1,5 @@
++package stdlib.primitives
+
+[] > null
+  0 > address
+  TRUE > @


### PR DESCRIPTION
null.eo:
```
[] > null
  0 > address
  TRUE > @
```

Understanding that given object is `null` will be executed by checking the `address` attribute.