### PR TITLE
#189: change var to val without deterioration in functionality.

### DIFF
--- a/src/main/kotlin/org/polystat/j2eo/eotree/EOMeta.kt
+++ b/src/main/kotlin/org/polystat/j2eo/eotree/EOMeta.kt
@@ -24,9 +24,6 @@ class EOMeta(var name: String, var value: String) : EONode() {
         return true
     }
 
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + value.hashCode()
-        return result
-    }
+    override fun hashCode(): Int =
+        31 * name.hashCode() + value.hashCode()
 }

--- a/src/main/kotlin/org/polystat/j2eo/translator/Translator.kt
+++ b/src/main/kotlin/org/polystat/j2eo/translator/Translator.kt
@@ -53,11 +53,11 @@ class Translator(val relativePath: Path) {
 
         // FIXME: assuming there is only one top-level component and it is a class
         val mainClassName = findMainClass(unit)
-        var entrypointBnds = listOf<EOBndExpr>()
-        if (mainClassName != null) {
-            entrypointBnds = generateEntryPoint(mainClassName)
+        val entrypointBnds = if (mainClassName != null) {
+            generateEntryPoint(mainClassName)
         } else {
             logger.info { "No entry point here!" }
+            listOf()
         }
 
         // FIXME: assuming there is only one top-level component and it is a class

--- a/src/main/kotlin/org/polystat/j2eo/treeMapper/TreeMappings.kt
+++ b/src/main/kotlin/org/polystat/j2eo/treeMapper/TreeMappings.kt
@@ -72,11 +72,13 @@ fun MemberDeclarationContext.toDeclaration(modifiers: List<ModifierContext>?): L
 fun ConstructorDeclarationContext.toDeclaration(modifiers: List<ModifierContext>?): Declaration {
     val excsTypes = qualifiedNameList()?.qualifiedName()?.map { TypeName(it.toCompoundName(), null) }
 
-    var excsTypeList: TypeList? = null
-    if (excsTypes != null) {
-        excsTypeList = TypeList(null)
-        excsTypeList.types = ArrayList(excsTypes)
+    val excsTypeList: TypeList? = if (excsTypes != null) {
+        TypeList(null)
+    } else {
+        null
     }
+
+    excsTypeList?.types = ArrayList(excsTypes)
 
     return ConstructorDeclaration(
         modifiers.getModifiers(),

--- a/src/test/kotlin/eotree/TestEOLicense.kt
+++ b/src/test/kotlin/eotree/TestEOLicense.kt
@@ -13,7 +13,7 @@ import java.util.stream.Collectors
 class TestEOLicense {
     @Test
     fun testGenerateEOZeroIndent() {
-        var license = EOLicense(
+        val license = EOLicense(
             EOComment("test comment 1"),
             EOComment("test comment 2")
         )
@@ -24,7 +24,7 @@ class TestEOLicense {
      # test comment 2
             """.trimIndent()
         )
-        license = EOLicense(
+        val licenseFromStream = EOLicense(
             Arrays.stream(
                 arrayOf(
                     EOComment("test comment 3"),
@@ -33,7 +33,7 @@ class TestEOLicense {
             ).collect(Collectors.toList())
         )
         Assertions.assertEquals(
-            license.generateEO(0),
+            licenseFromStream.generateEO(0),
             """
      # test comment 3
      # test comment 4
@@ -43,7 +43,7 @@ class TestEOLicense {
 
     @Test
     fun testGenerateEONonZeroIndent() {
-        var license = EOLicense(
+        val license = EOLicense(
             EOComment("test comment 5"),
             EOComment("test comment 6")
         )
@@ -54,7 +54,7 @@ class TestEOLicense {
      # test comment 6
             """.trimIndent()
         )
-        license = EOLicense(
+        val licenseFromStream = EOLicense(
             Arrays.stream(
                 arrayOf(
                     EOComment("test comment 7"),
@@ -63,7 +63,7 @@ class TestEOLicense {
             ).collect(Collectors.toList())
         )
         Assertions.assertEquals(
-            license.generateEO(1),
+            licenseFromStream.generateEO(1),
             """
      # test comment 7
      # test comment 8

--- a/src/test/kotlin/eotree/data/TestEOByte.kt
+++ b/src/test/kotlin/eotree/data/TestEOByte.kt
@@ -11,21 +11,21 @@ class TestEOByte {
     @Test
     fun testGenerateEOZeroIndent() {
         // Single-digit byte
-        var b = EOByte(1.toByte())
-        Assertions.assertEquals(b.generateEO(0), "01")
+        val oneByte = EOByte(1.toByte())
+        Assertions.assertEquals(oneByte.generateEO(0), "01")
 
         // Double-digit byte
-        b = EOByte(255.toByte())
-        Assertions.assertEquals(b.generateEO(0), "FF")
+        val maxByte = EOByte(255.toByte())
+        Assertions.assertEquals(maxByte.generateEO(0), "FF")
     }
 
     @Test
     fun testGenerateEONonZeroIndent() {
-        var b = EOByte(1.toByte())
-        Assertions.assertEquals(b.generateEO(1), "01")
+        val oneByte = EOByte(1.toByte())
+        Assertions.assertEquals(oneByte.generateEO(1), "01")
 
         // Double-digit byte
-        b = EOByte(255.toByte())
-        Assertions.assertEquals(b.generateEO(1), "FF")
+        val maxByte = EOByte(255.toByte())
+        Assertions.assertEquals(maxByte.generateEO(1), "FF")
     }
 }


### PR DESCRIPTION
fix main point [#189](https://github.com/polystat/j2eo/issues/189).

only two new lint errors spawns (path:  /main/kotlin/org/polystat/j2eo/treeMapper/):

1) TreeMappings.kt:75:27: [NULLABLE_PROPERTY_TYPE] try to avoid use of nullable types: don't use nullable type (diktat-ruleset:nullable-type)
2) TreeMappings.kt:75:43: [AVOID_NULL_CHECKS] Try to avoid explicit null-checks: use '.let/.also/?:/e.t.c' instead of excsTypes != null (diktat-ruleset:null-checks)